### PR TITLE
Improve Readability by updating CSS font family

### DIFF
--- a/index.css
+++ b/index.css
@@ -5,7 +5,7 @@ body {
   margin: 0;
   padding: 0;
   font-size: 22px;
-  font-family: wt011, Helvetica, Arial, sans-serif;
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
 }
 h1,
 h2,


### PR DESCRIPTION
Update body font family to reboot.css default settings because justfont wt011 is not clear enough to display English characters.